### PR TITLE
Fix Simulation and TimerLimit false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ information.
 3. `./gradlew build`
 4. The final jars will compile into the `<platform>/build/libs` folders
 
+## Recent False Positive Fixes
+
+- **Simulation – entity pressure on partial blocks.** Players who idle on short blocks such as chests or hoppers while clearing mob spawners now receive extra vertical lenience whenever nearby entities nudge them. The prediction engine checks the fractional height of the supporting surface and cushions the allowed offset based on the number of colliding entities, preventing the old Simulation spam while keeping normal movement strict.【F:common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java†L535-L546】
+- **TimerLimit – bursty ladder climbing.** Legitimate ladder and vine climbs can bunch several movement packets together, especially on high latency servers. TimerLimit now recognises active climbing and burns a configurable grace window (`climb-grace-ticks`, default 3) before flagging, letting players continue upward without unnecessary setbacks while still punishing sustained timer abuse.【F:common/src/main/java/ac/grim/grimac/checks/impl/timer/TimerLimit.java†L12-L80】【F:common/src/main/resources/config/en.yml†L140-L147】
+- **Simulation – fluid transitions (from SleazLee’s earlier PR).** The previous Simulation update reduced offsets when the player is interacting with bubble columns, flowing liquids, or shallow fluid contact by trimming the vertical component before comparison. This change specifically targets the jitter that appeared when swapping between water, lava, and dry ground, which had caused repeated Simulation alerts before the fix.【F:common/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java†L524-L546】
+
 ## Grim Supremacy
 
 What makes Grim stand out against other anticheats?

--- a/common/src/main/java/ac/grim/grimac/checks/impl/timer/TimerLimit.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/timer/TimerLimit.java
@@ -11,6 +11,7 @@ public class TimerLimit extends Timer {
 
     // At what ping should we start to limit the balance advantage? (nanos)
     private long limitAbuseOverPing;
+    private long climbingGraceWindow;
 
     public TimerLimit(GrimPlayer player) {
         super(player);
@@ -19,7 +20,12 @@ public class TimerLimit extends Timer {
     @Override
     public void doCheck(final PacketReceiveEvent event) {
         // 1:1 with Timer minus cancelling the packet
-        if (timerBalanceRealTime > System.nanoTime()) {
+        long now = System.nanoTime();
+        if (timerBalanceRealTime > now) {
+            if (applyClimbGrace(now)) {
+                limitFallBehind();
+                return;
+            }
             // If timer check already flagged, don't flag.
             if (!event.isCancelled()) {
                 if (flagAndAlert() && shouldSetback()) {
@@ -32,6 +38,24 @@ public class TimerLimit extends Timer {
         }
 
         limitFallBehind();
+    }
+
+    private boolean applyClimbGrace(long now) {
+        if (climbingGraceWindow <= 0) {
+            return false;
+        }
+
+        if (!(player.isClimbing || player.pointThreeEstimator.isNearClimbable())) {
+            return false;
+        }
+
+        long lead = timerBalanceRealTime - now;
+        if (lead <= 0 || lead > climbingGraceWindow) {
+            return false;
+        }
+
+        timerBalanceRealTime = Math.max(timerBalanceRealTime - 50_000_000L, now);
+        return true;
     }
 
     @Override
@@ -51,5 +75,7 @@ public class TimerLimit extends Timer {
         if (limitAbuseOverPing != -1) {
             limitAbuseOverPing *= (long) 1e6;
         }
+        double climbGraceTicks = config.getDoubleElse(getConfigName() + ".climb-grace-ticks", 3.0);
+        climbingGraceWindow = climbGraceTicks <= 0 ? 0 : (long) (climbGraceTicks * 50e6);
     }
 }

--- a/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -538,6 +538,14 @@ public class PredictionEngine {
         double additionHorizontal = player.uncertaintyHandler.getOffsetHorizontal(vector);
         double additionVertical = player.uncertaintyHandler.getVerticalOffset(vector);
 
+        if (avgColliding > 0) {
+            double supportFraction = player.boundingBox.minY - Math.floor(player.boundingBox.minY);
+            if (supportFraction > 1E-6 && supportFraction < 1 - 1E-6) {
+                double verticalLenience = Math.min(0.06, 0.01 + 0.01 * avgColliding);
+                additionVertical += verticalLenience;
+            }
+        }
+
         double pistonX = Collections.max(player.uncertaintyHandler.pistonX);
         double pistonY = Collections.max(player.uncertaintyHandler.pistonY);
         double pistonZ = Collections.max(player.uncertaintyHandler.pistonZ);

--- a/common/src/main/resources/config/de.yml
+++ b/common/src/main/resources/config/de.yml
@@ -142,6 +142,9 @@ TimerLimit:
     # Can cause some setbacks for legitimate players but only if they are over this ping threshold.
     # -1 to disable
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Anzahl der Millisekunden, die während der Bewegung verloren gehen, bevor mit der Markierung begonnen werden sollte.

--- a/common/src/main/resources/config/en.yml
+++ b/common/src/main/resources/config/en.yml
@@ -142,6 +142,9 @@ TimerLimit:
     # Can cause some setbacks for legitimate players but only if they are over this ping threshold.
     # -1 to disable
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Number of milliseconds lost while moving before we should start flagging

--- a/common/src/main/resources/config/es.yml
+++ b/common/src/main/resources/config/es.yml
@@ -147,6 +147,9 @@ TimerLimit:
     # Can cause some setbacks for legitimate players but only if they are over this ping threshold.
     # -1 to disable
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Number of milliseconds lost while moving before we should start flagging

--- a/common/src/main/resources/config/fr.yml
+++ b/common/src/main/resources/config/fr.yml
@@ -143,6 +143,9 @@ TimerLimit:
     # Can cause some setbacks for legitimate players but only if they are over this ping threshold.
     # -1 to disable
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Le nombre de millisecondes perdus pendant le déplacement avant de commencer à signaler des infractions.

--- a/common/src/main/resources/config/it.yml
+++ b/common/src/main/resources/config/it.yml
@@ -134,6 +134,9 @@ TimerLimit:
     # Can cause some setbacks for legitimate players but only if they are over this ping threshold.
     # -1 to disable
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Millisecondi persi prima di rilevare il timer negativo

--- a/common/src/main/resources/config/ja.yml
+++ b/common/src/main/resources/config/ja.yml
@@ -146,6 +146,9 @@ TimerLimit:
     # 正当なプレイヤーであっても、このPingのしきい値を超えるとセットバックが発生する場合があります
     # -1で無効化
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # プレイヤーが移動中にどれだけミリ秒の遅延が発生した場合にフラグを立て始めるかを指定します

--- a/common/src/main/resources/config/nl.yml
+++ b/common/src/main/resources/config/nl.yml
@@ -142,6 +142,9 @@ TimerLimit:
     # Kan wat tegenslag veroorzaken voor legitieme spelers, maar alleen als ze boven deze ping drempel zitten.
     # -1 om uit te schakelen
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Aantal milliseconden dat verloren gaat tijdens het bewegen voordat we moeten beginnen met flaggen

--- a/common/src/main/resources/config/pt.yml
+++ b/common/src/main/resources/config/pt.yml
@@ -145,6 +145,9 @@ TimerLimit:
     # Pode causar recuos a jogadores legítmos, mas somente se estiverem acima desse ping.
     # -1 desabilitará.
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Número de milissegundos perdidos ao se mover antes de começarmos a registrar violações.

--- a/common/src/main/resources/config/ru.yml
+++ b/common/src/main/resources/config/ru.yml
@@ -143,6 +143,9 @@ TimerLimit:
     # Can cause some setbacks for legitimate players but only if they are over this ping threshold.
     # -1 to disable
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Количество миллисекунд, потерянных во время движения, до того, как мы начнем ставить флаг

--- a/common/src/main/resources/config/tr.yml
+++ b/common/src/main/resources/config/tr.yml
@@ -142,6 +142,9 @@ TimerLimit:
     # Bu, yalnızca bu ping eşiğini aşan meşru oyuncular için bazı geri dönüşlere neden olabilir.
     # Devre dışı bırakmak için -1 yazın
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # Uyarı vermeye başlamadan önce hareket halindeyken kaybedilen milisaniye sayısı

--- a/common/src/main/resources/config/zh.yml
+++ b/common/src/main/resources/config/zh.yml
@@ -147,6 +147,9 @@ TimerLimit:
     # 在合法玩家的延迟超过这个延迟阈值时可能会造成误拉回
     # 填写-1则关闭
     ping-abuse-limit-threshold: 1000
+    # Number of ticks of timer balance we forgive while a player is climbing.
+    # Lets legitimate ladder/vine movement absorb small bursty packets without creating violations.
+    climb-grace-ticks: 3
 
 NegativeTimer:
     # 在开始检查玩家时，玩家的移动丢失了多少毫秒数


### PR DESCRIPTION
## Summary
- add Simulation lenience for entity pressure while players stand on partial-height blocks to eliminate the chest spawner false positives
- let TimerLimit forgive a configurable burst of packets while players are actively climbing so ladders no longer spam flags
- document the recent Simulation and TimerLimit fixes in the README for hand-off to the original developer

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d6cdbc1b008332a3d3e720549a3264